### PR TITLE
Store header keys in lower case

### DIFF
--- a/src/Response/CurlResponse.php
+++ b/src/Response/CurlResponse.php
@@ -60,7 +60,7 @@ class CurlResponse
                 continue;
             }
             [$key, $value] = explode(': ', $header);
-            $responseHeaders[$key] = [rtrim($value)];
+            $responseHeaders[strtolower($key)] = [rtrim($value)];
         }
         $this->headers = $responseHeaders;
     }


### PR DESCRIPTION
The getHeader() method assumes all header keys are in lower case. Make sure they are.